### PR TITLE
Export, transform and send of mismatch info

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ Set IRELAND_RDS_* & LONDON_RDS_* environment vars appropriately
 Ensure there are mismatching records across "Ireland" and "London" LOCAL Claimant API RDS databases for a matching NINO  
 Ensure you have correctly set all of the environment variables in the above table  
 Run `make run-local`, this will use the example event `resources/event.json`
+
+# Data analysis
+
+Fetch sample data for a given time period via AWS CLI. Replacing TABLE-NAME and PROFILE with the respective values.
+```
+aws dynamodb scan --table-name TABLE-NAME --filter-expression 'contains(recorded_datetime,:date)' --expression-attribute-values '{":date":{"S":"2021-03-06T"}}' --profile PROFILE --region eu-west-1 --output json > claimant_api.json
+```
+
+Run the `dynamodb_to_csv` script to convert the DynamoDb output to CSV for the mismatch dynamodb table structure.
+Send this CSV to UC via secure means.

--- a/dynamodb_to_csv.py
+++ b/dynamodb_to_csv.py
@@ -40,5 +40,5 @@ with open("claimant_mismatch.csv", "w", newline="") as csvfile:
         file = open("claimant_mismatch.json", "r")
         return json.loads(file.read())
 
-    json = load_json()
-    json_to_csv(json)
+    json_file = load_json()
+    json_to_csv(json_file)

--- a/dynamodb_to_csv.py
+++ b/dynamodb_to_csv.py
@@ -1,0 +1,44 @@
+import json
+import csv
+
+field_names = [
+    "nino",
+    "statement_id",
+    "recorded_datetime",
+    "decrypted_take_home_pay",
+    "contract_id_ire",
+    "contract_id_ldn",
+    "ap_start_date_ire",
+    "ap_end_date_ire",
+    "ap_start_date_ldn",
+    "ap_end_date_ldn",
+    "suspension_date_ire",
+    "suspension_date_ldn",
+    "statement_created_date_ire",
+    "statement_created_date_ldn"
+]
+
+with open('claimant_mismatch.csv', 'w', newline='') as csvfile:
+    csvwriter = csv.DictWriter(csvfile, fieldnames=field_names)
+
+    csvwriter.writeheader()
+
+    def json_to_csv(json):
+        for item in json["Items"]:
+            row_items = {}
+
+            for key, value in item.items():
+                subkey, subvalue = list(value.items())[0]
+                if subkey == "NULL":
+                    row_items[key] = "null"
+                else:
+                    row_items[key] = subvalue
+
+            csvwriter.writerow(row_items)
+
+    def load_json():
+        file = open("claimant_mismatch.json", "r")
+        return json.loads(file.read())
+
+    json = load_json()
+    json_to_csv(json)

--- a/dynamodb_to_csv.py
+++ b/dynamodb_to_csv.py
@@ -15,10 +15,10 @@ field_names = [
     "suspension_date_ire",
     "suspension_date_ldn",
     "statement_created_date_ire",
-    "statement_created_date_ldn"
+    "statement_created_date_ldn",
 ]
 
-with open('claimant_mismatch.csv', 'w', newline='') as csvfile:
+with open("claimant_mismatch.csv", "w", newline="") as csvfile:
     csvwriter = csv.DictWriter(csvfile, fieldnames=field_names)
 
     csvwriter.writeheader()

--- a/src/replayer_mismatch/handler.py
+++ b/src/replayer_mismatch/handler.py
@@ -186,8 +186,8 @@ def dynamodb_format(
 
     statement_id = _handle_type(statement_id)
 
-    contract_id_ire = _handle_type(ireland_additional_data.get("contractId", ""))
-    contract_id_ldn = _handle_type(london_additional_data.get("contractId", ""))
+    contract_id_ire = _handle_type(ireland_additional_data.get("contract_id", ""))
+    contract_id_ldn = _handle_type(london_additional_data.get("contract_id", ""))
 
     ap_start_date_ire = _handle_type(ireland_additional_data.get("apStartDate", ""))
     ap_end_date_ire = _handle_type(ireland_additional_data.get("apEndDate", ""))

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -60,7 +60,7 @@ mock_params.__dict__ = {
 additional_record_data = {
     "nino": "123",
     "statementId": "123",
-    "contractId": "123",
+    "contract_id": "123",
     "apStartDate": "123",
     "apEndDate": "123",
     "suspensionDate": "123",
@@ -322,7 +322,7 @@ class TestHandler(unittest.TestCase):
             take_home_pay = "123"
             ireland_additional_data = {
                 "statementId": "123_ire".encode(),
-                "contractId": "123_ire".encode(),
+                "contract_id": "123_ire".encode(),
                 "apStartDate": "123_ire".encode(),
                 "apEndDate": "123_ire".encode(),
                 "suspensionDate": "123_ire".encode(),
@@ -331,7 +331,7 @@ class TestHandler(unittest.TestCase):
 
             london_additional_data = {
                 "statementId": "123_ldn".encode(),
-                "contractId": "123_ldn".encode(),
+                "contract_id": "123_ldn".encode(),
                 "apStartDate": "123_ldn".encode(),
                 "apEndDate": "123_ldn".encode(),
                 "suspensionDate": "123_ldn".encode(),
@@ -368,7 +368,7 @@ class TestHandler(unittest.TestCase):
             nino = "123"
             take_home_pay = "123"
             ireland_additional_data = {
-                "contractId": "123_ire".encode(),
+                "contract_id": "123_ire".encode(),
                 "apStartDate": "123_ire".encode(),
                 "apEndDate": "123_ire".encode(),
                 "suspensionDate": "123_ire".encode(),
@@ -377,7 +377,7 @@ class TestHandler(unittest.TestCase):
 
             london_additional_data = {
                 "statementId": "123_ldn".encode(),
-                "contractId": "123_ldn".encode(),
+                "contract_id": "123_ldn".encode(),
                 "apStartDate": "123_ldn".encode(),
                 "apEndDate": "123_ldn".encode(),
                 "suspensionDate": "123_ldn".encode(),
@@ -399,7 +399,7 @@ class TestHandler(unittest.TestCase):
             nino = "123"
             take_home_pay = "123"
             ireland_additional_data = {
-                "contractId": "123_ire".encode(),
+                "contract_id": "123_ire".encode(),
                 "apStartDate": "123_ire".encode(),
                 "apEndDate": "123_ire".encode(),
                 "suspensionDate": "123_ire".encode(),
@@ -407,7 +407,7 @@ class TestHandler(unittest.TestCase):
             }
 
             london_additional_data = {
-                "contractId": "123_ldn".encode(),
+                "contract_id": "123_ldn".encode(),
                 "apStartDate": "123_ldn".encode(),
                 "apEndDate": "123_ldn".encode(),
                 "suspensionDate": "123_ldn".encode(),


### PR DESCRIPTION
Supporting script to transform the dynamodb output to CSV format.
Modify contractId to be contract_id as that is the name of it on the database.